### PR TITLE
Handle discovery print with vectors

### DIFF
--- a/R/bids_facade_phase1.R
+++ b/R/bids_facade_phase1.R
@@ -71,8 +71,18 @@ discover.bids_facade <- function(x, ...) {
 #' @export
 print.bids_discovery_simple <- function(x, ...) {
   cat("\u2728 BIDS Discovery\n")
-  cat(length(x$participants$participant_id), "participants\n")
-  cat(length(x$tasks$task_id), "tasks\n")
+  part_count <- if (is.data.frame(x$participants)) {
+    nrow(x$participants)
+  } else {
+    length(x$participants)
+  }
+  task_count <- if (is.data.frame(x$tasks)) {
+    nrow(x$tasks)
+  } else {
+    length(x$tasks)
+  }
+  cat(part_count, "participants\n")
+  cat(task_count, "tasks\n")
   invisible(x)
 }
 

--- a/R/bids_facade_phase2.R
+++ b/R/bids_facade_phase2.R
@@ -51,8 +51,18 @@ discover.bids_facade <- function(x, ...) {
 #' @export
 print.bids_discovery_enhanced <- function(x, ...) {
   cat("\u2728 BIDS Discovery\n")
-  cat(nrow(x$participants), "participants\n")
-  cat(nrow(x$tasks), "tasks\n")
+  part_count <- if (is.data.frame(x$participants)) {
+    nrow(x$participants)
+  } else {
+    length(x$participants)
+  }
+  task_count <- if (is.data.frame(x$tasks)) {
+    nrow(x$tasks)
+  } else {
+    length(x$tasks)
+  }
+  cat(part_count, "participants\n")
+  cat(task_count, "tasks\n")
   if (!is.null(x$quality)) {
     cat("Quality metrics available\n")
   }

--- a/tests/testthat/test-bids-facade-phase1.R
+++ b/tests/testthat/test-bids-facade-phase1.R
@@ -152,6 +152,22 @@ test_that("discover() produces beautiful output", {
   expect_true(any(grepl("2 tasks", output)))
 })
 
+test_that("print.bids_discovery_simple handles character vectors", {
+  skip_if_not_installed("bidser")
+
+  mock_discovery <- list(
+    participants = c("sub-01", "sub-02", "sub-03"),
+    tasks = c("rest", "memory"),
+    sessions = NULL,
+    summary = list()
+  )
+  class(mock_discovery) <- "bids_discovery_simple"
+
+  output <- capture.output(print(mock_discovery))
+  expect_true(any(grepl("3 participants", output)))
+  expect_true(any(grepl("2 tasks", output)))
+})
+
 test_that("as.fmri_dataset method exists and delegates properly", {
   skip_if_not_installed("bidser")
   

--- a/tests/testthat/test-bids-facade-phase2.R
+++ b/tests/testthat/test-bids-facade-phase2.R
@@ -54,6 +54,23 @@ test_that("enhanced discover() includes quality metrics", {
   expect_true(any(grepl("Quality metrics available", output)))
 })
 
+test_that("print.bids_discovery_enhanced handles character vectors", {
+  skip_if_not_installed("bidser")
+
+  mock_discovery <- list(
+    summary = list(),
+    participants = c("sub-01", "sub-02"),
+    tasks = c("rest", "memory"),
+    sessions = NULL,
+    quality = NULL
+  )
+  class(mock_discovery) <- "bids_discovery_enhanced"
+
+  output <- capture.output(print(mock_discovery))
+  expect_true(any(grepl("2 participants", output)))
+  expect_true(any(grepl("2 tasks", output)))
+})
+
 test_that("assess_quality() provides comprehensive quality metrics", {
   skip_if_not_installed("bidser")
   


### PR DESCRIPTION
## Summary
- fix print functions to count data frames and vectors
- test printing when participants and tasks are vectors

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b7108e938832db6b1769af80cb22e