### PR TITLE
Add path validation to bids()

### DIFF
--- a/R/bids_facade_phase1.R
+++ b/R/bids_facade_phase1.R
@@ -35,6 +35,13 @@ discover <- function(x, ...) {
 #' @export
 bids <- function(path, ...) {
   check_package_available("bidser", "BIDS access", error = TRUE)
+
+  if (!dir.exists(path)) {
+    stop("BIDS directory does not exist: ", path)
+  }
+
+  path <- normalizePath(path, mustWork = TRUE)
+
   proj <- bidser::bids_project(path, ...)
   obj <- list(
     path = path,

--- a/tests/testthat/test-bids-facade-phase1.R
+++ b/tests/testthat/test-bids-facade-phase1.R
@@ -27,7 +27,7 @@ test_that("bids() creates elegant facade around bidser::bids_project", {
     participants = c("sub-01", "sub-02"),
     file_structure = file_structure_df
   )
-  
+
   # Test that we can create a facade from mock data (check mock_bids_project which is what we get)
   expect_true(inherits(mock_bids, "mock_bids_project"))
   
@@ -42,6 +42,14 @@ test_that("bids() creates elegant facade around bidser::bids_project", {
     
     unlink(temp_dir, recursive = TRUE)
   }
+})
+
+test_that("bids() errors when directory is missing", {
+  skip_if_not_installed("bidser")
+
+  fake_dir <- tempfile("no_such_bids")
+  expect_false(dir.exists(fake_dir))
+  expect_error(bids(fake_dir), "BIDS directory does not exist")
 })
 
 test_that("bids_facade object has correct structure and methods", {


### PR DESCRIPTION
## Summary
- check directory existence before calling `bidser::bids_project`
- normalize path to avoid relative path issues
- test for informative error on nonexistent directory

## Testing
- `R -q -e "print('hello')"` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b710df434832d9239a715e9861118