### PR TITLE
Improve scan retrieval error handling

### DIFF
--- a/R/bids_facade_phase2.R
+++ b/R/bids_facade_phase2.R
@@ -76,14 +76,24 @@ assess_quality.bids_facade <- function(x, subject_id, session_id = NULL,
     error = function(e) NULL
   )
 
-  scans <- bidser::func_scans(x$project,
-                              subject_id = subject_id,
-                              session_id = session_id,
-                              task_id = task_id,
-                              run_ids = run_ids)
+  scans <- tryCatch(
+    bidser::func_scans(x$project,
+                       subject_id = subject_id,
+                       session_id = session_id,
+                       task_id = task_id,
+                       run_ids = run_ids),
+    error = function(e) {
+      warning("Could not retrieve functional scans: ", conditionMessage(e))
+      NULL
+    }
+  )
 
-  metrics <- tryCatch(bidser::check_func_scans(scans),
-                      error = function(e) NULL)
+  metrics <- if (is.null(scans)) {
+    NULL
+  } else {
+    tryCatch(bidser::check_func_scans(scans),
+             error = function(e) NULL)
+  }
 
   mask <- tryCatch(
     bidser::create_preproc_mask(x$project,

--- a/tests/testthat/test-bids-facade-phase2.R
+++ b/tests/testthat/test-bids-facade-phase2.R
@@ -310,4 +310,20 @@ test_that("quality threshold and filtering logic", {
   # Test overall quality assessment
   percent_good_quality <- (excellent_timepoints + good_timepoints) / length(mock_fd_data) * 100
   expect_true(percent_good_quality > 50)  # Should have majority good quality
-}) 
+})
+
+test_that("warning emitted when scans cannot be retrieved", {
+  skip_if_not_installed("bidser")
+
+  bad_facade <- list(
+    path = "/bad/path",
+    project = list(),
+    cache = new.env(parent = emptyenv())
+  )
+  class(bad_facade) <- "bids_facade"
+
+  expect_warning(
+    assess_quality(bad_facade, subject_id = "sub-01"),
+    "Could not retrieve functional scans"
+  )
+})


### PR DESCRIPTION
## Summary
- handle failed `func_scans()` calls in `assess_quality.bids_facade`
- warn when functional scans cannot be retrieved
- test warning behaviour when `func_scans` fails

## Testing
- `Rscript -e 'library(testthat); test_dir("tests/testthat")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b711044ac832da4a481fd8ac302cf