### PR TITLE
Handle multi-task inputs in BIDS facade

### DIFF
--- a/R/bids_facade_phase1.R
+++ b/R/bids_facade_phase1.R
@@ -81,5 +81,11 @@ print.bids_discovery_simple <- function(x, ...) {
 # ---------------------------------------------------------------------------
 #' @export
 as.fmri_dataset.bids_facade <- function(x, ...) {
-  as.fmri_dataset(x$project, ...)
+  args <- list(...)
+  task_id <- args$task_id
+  if (!is.null(task_id) && length(task_id) > 1) {
+    stop("Only one task_id may be supplied when converting a bids_facade", 
+         call. = FALSE)
+  }
+  do.call(as.fmri_dataset, c(list(x$project), args))
 }

--- a/R/bids_facade_phase4.R
+++ b/R/bids_facade_phase4.R
@@ -79,6 +79,12 @@ create_dataset.bids_facade <- function(x, subject_id, ...) {
       image_type <- x$nl_filters$pipeline
     }
   }
+
+  if (!is.null(task_id) && length(task_id) > 1) {
+    stop("create_dataset() expects a single task_id; found: ",
+         paste(task_id, collapse = ", "), call. = FALSE)
+  }
+
   as.fmri_dataset(x$project,
                   subject_id = subject_id,
                   task_id = task_id,

--- a/tests/testthat/test-bids-facade-phase1.R
+++ b/tests/testthat/test-bids-facade-phase1.R
@@ -167,6 +167,23 @@ test_that("as.fmri_dataset method exists and delegates properly", {
   expect_true(exists("as.fmri_dataset.bids_facade"))
 })
 
+test_that("as.fmri_dataset.bids_facade errors on multiple tasks", {
+  skip_if_not_installed("bidser")
+
+  mock_facade <- list(
+    path = "/test/path",
+    project = list(),
+    cache = new.env()
+  )
+  class(mock_facade) <- "bids_facade"
+
+  expect_error(
+    as.fmri_dataset.bids_facade(mock_facade, subject_id = "01",
+                                task_id = c("rest", "memory")),
+    "single task_id"
+  )
+})
+
 test_that("error handling works gracefully", {
   skip_if_not_installed("bidser")
   

--- a/tests/testthat/test-bids-facade-phase4.R
+++ b/tests/testthat/test-bids-facade-phase4.R
@@ -226,6 +226,23 @@ test_that("create_dataset() integrates filters correctly", {
   expect_null(mock_facade_no_filters$nl_filters)
 })
 
+test_that("create_dataset() errors with multiple tasks", {
+  skip_if_not_installed("bidser")
+
+  mock_facade <- list(
+    path = "/test/path",
+    project = list(),
+    cache = new.env(parent = emptyenv()),
+    nl_filters = list(task = c("rest", "memory"))
+  )
+  class(mock_facade) <- "bids_facade"
+
+  expect_error(
+    create_dataset.bids_facade(mock_facade, subject_id = "01"),
+    "single task_id"
+  )
+})
+
 test_that("complex conversational workflows work end-to-end", {
   skip_if_not_installed("bidser")
   


### PR DESCRIPTION
## Summary
- validate that only one `task_id` is supplied before delegating to `as.fmri_dataset`
- raise errors in `create_dataset()` and `as.fmri_dataset.bids_facade` when multiple tasks are present
- test multi-task error handling for both helper functions

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b711f643c832d893caba82f300ae4