### PR TITLE
Implement BIDS backend helpers

### DIFF
--- a/examples/elegant_bids_demo.R
+++ b/examples/elegant_bids_demo.R
@@ -119,6 +119,9 @@ cat("\n=== Discovery Interface ===\n")
 # This demonstrates what the discovery interface would look like
 cat("# Discover what's available in a BIDS dataset:\n")
 cat("discovery <- bids_discover('/path/to/bids')\n\n")
+cat("# Access helper functions for quick lists:\n")
+cat("subjects <- discover_subjects(discovery$backend, '/path/to/bids')\n")
+cat("tasks <- discover_tasks(discovery$backend, '/path/to/bids')\n\n")
 
 cat("# The discovery object would contain:\n")
 cat("# - discovery$subjects: c('01', '02', '03', ...)\n")

--- a/tests/testthat/test-bids-interface.R
+++ b/tests/testthat/test-bids-interface.R
@@ -1,0 +1,34 @@
+skip_if_not_installed <- function(pkg) {
+  skip_if_not(requireNamespace(pkg, quietly = TRUE),
+              paste("Package", pkg, "not available"))
+}
+
+context("BIDS interface backend helpers")
+
+test_that("bidser backend discovery helpers work", {
+  skip_if_not_installed("bidser")
+
+  fs <- data.frame(
+    subid = c("sub-01"),
+    datatype = c("func"),
+    suffix = c("bold"),
+    fmriprep = c(FALSE),
+    task = c("rest"),
+    stringsAsFactors = FALSE
+  )
+
+  mock_bids <- bidser::create_mock_bids(
+    project_name = "backend_test",
+    participants = c("sub-01"),
+    file_structure = fs
+  )
+
+  backend <- bids_backend("bidser", backend_config = list(prefer_preproc = FALSE))
+
+  scans <- backend$find_scans(mock_bids, list(subjects = "01"))
+  expect_true(is.character(scans))
+
+  subs <- discover_subjects(backend, mock_bids)
+  expect_true(length(subs) >= 1)
+})
+


### PR DESCRIPTION
## Summary
- implement bidser backend logic and discovery helpers
- show backend configuration in docs
- demonstrate discovery helper usage in example
- add tests for new helper functions

## Testing
- `R -q -e "1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b7131a90c832d88e3e6bb4fc0a4ef