### PR TITLE
Implement BIDS query generics

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -107,6 +107,8 @@ export(session)
 export(run)
 export(derivatives)
 export(space)
+export(find_scans)
+export(get_run_info)
 
 # ============================================================================
 # S3 Methods
@@ -167,6 +169,10 @@ S3method(session, bids_query)
 S3method(run, bids_query)
 S3method(derivatives, bids_query)
 S3method(space, bids_query)
+S3method(find_scans, bids_query)
+S3method(get_metadata, fmri_dataset)
+S3method(get_metadata, bids_query)
+S3method(get_run_info, bids_query)
 
 # fmri_data_chunk methods
 S3method(print, fmri_data_chunk)

--- a/R/aaa_generics.R
+++ b/R/aaa_generics.R
@@ -235,3 +235,28 @@ apply_workflow <- function(x, ...) {
 discover_best_practices <- function(...) {
   UseMethod("discover_best_practices")
 }
+
+#' Find Scans Matching a BIDS Query
+#'
+#' Generic function for locating scans that satisfy a `bids_query`.
+#'
+#' @param x Object to search for scans
+#' @param ... Additional arguments passed to methods
+#' @return Character vector of scan file paths
+#' @export
+find_scans <- function(x, ...) {
+  UseMethod("find_scans")
+}
+
+#' Get Run Information
+#'
+#' Generic function for retrieving run-level information such as run
+#' lengths from objects like `bids_query`.
+#'
+#' @param x Object to query
+#' @param ... Additional arguments passed to methods
+#' @return Run information, typically a vector of run lengths
+#' @export
+get_run_info <- function(x, ...) {
+  UseMethod("get_run_info")
+}

--- a/R/bids_interface.R
+++ b/R/bids_interface.R
@@ -273,6 +273,46 @@ space.bids_query <- function(query, ...) {
   return(query)
 }
 
+#' Find Scans for a BIDS Query
+#'
+#' Executes the query using the associated backend and returns the
+#' paths to matching scan files.
+#'
+#' @param x A `bids_query` object
+#' @param ... Additional arguments passed to the backend
+#' @return Character vector of scan paths
+#' @export
+find_scans.bids_query <- function(x, ...) {
+  x$backend$find_scans(x$bids_root, x$filters)
+}
+
+#' Retrieve Metadata for Scans in a Query
+#'
+#' Reads metadata for each scan returned by `find_scans()`.
+#'
+#' @param x A `bids_query` object
+#' @param ... Additional arguments passed to the backend
+#' @return List of metadata entries, one per scan
+#' @export
+get_metadata.bids_query <- function(x, ...) {
+  scans <- find_scans(x, ...)
+  lapply(scans, x$backend$read_metadata)
+}
+
+#' Get Run Information for a Query
+#'
+#' Retrieves run-level information (e.g., run lengths) for the scans
+#' matched by the query.
+#'
+#' @param x A `bids_query` object
+#' @param ... Additional arguments passed to the backend
+#' @return Backend-specific run information
+#' @export
+get_run_info.bids_query <- function(x, ...) {
+  scans <- find_scans(x, ...)
+  x$backend$get_run_info(scans)
+}
+
 # ============================================================================
 # BIDS Discovery Interface
 # ============================================================================

--- a/R/fmri_dataset_accessors.R
+++ b/R/fmri_dataset_accessors.R
@@ -337,6 +337,19 @@ get_censor_vector <- function(x) {
   return(x$censor_vector)
 }
 
+#' Get Metadata
+#'
+#' Generic function to retrieve metadata from objects such as
+#' `fmri_dataset` or `bids_query`.
+#'
+#' @param x Object to retrieve metadata from
+#' @param ... Additional arguments passed to methods
+#' @return Metadata list or object-specific value
+#' @export
+get_metadata <- function(x, ...) {
+  UseMethod("get_metadata")
+}
+
 #' Get Metadata from fmri_dataset
 #'
 #' **Ticket #14**: Accesses metadata list with optional field selection.
@@ -346,18 +359,18 @@ get_censor_vector <- function(x) {
 #' @return Metadata list or specific field value
 #' @export
 #' @family fmri_dataset
-get_metadata <- function(x, field = NULL) {
+get_metadata.fmri_dataset <- function(x, field = NULL, ...) {
   if (!is.fmri_dataset(x)) {
     stop("x must be an fmri_dataset object")
   }
-  
+
   if (is.null(field)) {
     return(x$metadata)
   } else {
     if (field %in% names(x$metadata)) {
       return(x$metadata[[field]])
     } else {
-      stop("Metadata field '", field, "' not found. Available fields: ", 
+      stop("Metadata field '", field, "' not found. Available fields: ",
            paste(names(x$metadata), collapse = ", "))
     }
   }

--- a/examples/elegant_bids_demo.R
+++ b/examples/elegant_bids_demo.R
@@ -65,7 +65,8 @@ cat("  space('MNI152NLin2009cAsym')\n\n")
 
 cat("# Execute query:\n")
 cat("scans <- query %>% find_scans()\n")
-cat("metadata <- query %>% get_metadata()\n\n")
+cat("metadata <- query %>% get_metadata()\n")
+cat("run_info <- query %>% get_run_info()\n\n")
 
 cat("# Direct dataset creation:\n")
 cat("dataset <- query %>% as_fmri_dataset(subject_id = '01')\n\n")


### PR DESCRIPTION
## Summary
- add S3 generics `find_scans()` and `get_run_info()`
- convert `get_metadata()` to a generic
- implement methods for `bids_query` objects
- update example to show `get_run_info()`
- export new functions and register S3 methods

## Testing
- `Rscript tests/run_tests.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b7133a03c832d91176b6865c2ab61