### PR TITLE
Validate BIDS query inputs

### DIFF
--- a/R/bids_interface.R
+++ b/R/bids_interface.R
@@ -33,6 +33,10 @@ NULL
 #'   ))
 #' }
 bids_backend <- function(backend_type = "bidser", backend_config = list()) {
+
+  if (!is.list(backend_config)) {
+    stop("backend_config must be a list")
+  }
   
   # Validate backend type
   supported_backends <- c("bidser", "pybids", "custom")
@@ -214,6 +218,19 @@ bids_query <- function(bids_root, backend = NULL) {
 #' @export
 subject.bids_query <- function(query, ...) {
   subjects <- c(...)
+
+  if (length(subjects) == 0) {
+    return(query)
+  }
+  if (!is.character(subjects)) {
+    warning("subject IDs must be character; coercing")
+    subjects <- as.character(subjects)
+  }
+  if (anyNA(subjects)) {
+    warning("NA subject IDs removed")
+    subjects <- subjects[!is.na(subjects)]
+  }
+
   query$filters$subjects <- union(query$filters$subjects, subjects)
   return(query)
 }
@@ -225,6 +242,19 @@ subject.bids_query <- function(query, ...) {
 #' @export
 task.bids_query <- function(query, ...) {
   tasks <- c(...)
+
+  if (length(tasks) == 0) {
+    return(query)
+  }
+  if (!is.character(tasks)) {
+    warning("task names must be character; coercing")
+    tasks <- as.character(tasks)
+  }
+  if (anyNA(tasks)) {
+    warning("NA task names removed")
+    tasks <- tasks[!is.na(tasks)]
+  }
+
   query$filters$tasks <- union(query$filters$tasks, tasks)
   return(query)
 }
@@ -236,6 +266,19 @@ task.bids_query <- function(query, ...) {
 #' @export
 session.bids_query <- function(query, ...) {
   sessions <- c(...)
+
+  if (length(sessions) == 0) {
+    return(query)
+  }
+  if (!is.character(sessions)) {
+    warning("session IDs must be character; coercing")
+    sessions <- as.character(sessions)
+  }
+  if (anyNA(sessions)) {
+    warning("NA session IDs removed")
+    sessions <- sessions[!is.na(sessions)]
+  }
+
   query$filters$sessions <- union(query$filters$sessions, sessions)
   return(query)
 }
@@ -247,6 +290,19 @@ session.bids_query <- function(query, ...) {
 #' @export
 run.bids_query <- function(query, ...) {
   runs <- c(...)
+
+  if (length(runs) == 0) {
+    return(query)
+  }
+  if (!is.character(runs)) {
+    warning("run numbers must be character; coercing")
+    runs <- as.character(runs)
+  }
+  if (anyNA(runs)) {
+    warning("NA run numbers removed")
+    runs <- runs[!is.na(runs)]
+  }
+
   query$filters$runs <- union(query$filters$runs, runs)
   return(query)
 }
@@ -258,6 +314,19 @@ run.bids_query <- function(query, ...) {
 #' @export
 derivatives.bids_query <- function(query, ...) {
   derivatives <- c(...)
+
+  if (length(derivatives) == 0) {
+    return(query)
+  }
+  if (!is.character(derivatives)) {
+    warning("derivative names must be character; coercing")
+    derivatives <- as.character(derivatives)
+  }
+  if (anyNA(derivatives)) {
+    warning("NA derivative names removed")
+    derivatives <- derivatives[!is.na(derivatives)]
+  }
+
   query$filters$derivatives <- union(query$filters$derivatives, derivatives)
   return(query)
 }
@@ -269,6 +338,19 @@ derivatives.bids_query <- function(query, ...) {
 #' @export
 space.bids_query <- function(query, ...) {
   spaces <- c(...)
+
+  if (length(spaces) == 0) {
+    return(query)
+  }
+  if (!is.character(spaces)) {
+    warning("space names must be character; coercing")
+    spaces <- as.character(spaces)
+  }
+  if (anyNA(spaces)) {
+    warning("NA space names removed")
+    spaces <- spaces[!is.na(spaces)]
+  }
+
   query$filters$spaces <- union(query$filters$spaces, spaces)
   return(query)
 }

--- a/tests/testthat/test-bids-query-validation.R
+++ b/tests/testthat/test-bids-query-validation.R
@@ -1,0 +1,52 @@
+library(testthat)
+
+# minimal custom backend for testing
+mock_backend <- bids_backend(
+  "custom",
+  backend_config = list(
+    find_scans = function(...) NULL,
+    read_metadata = function(...) NULL,
+    get_run_info = function(...) NULL
+  )
+)
+
+
+test_that("bids_backend validates backend_config type", {
+  expect_error(bids_backend("custom", backend_config = "oops"),
+               "backend_config must be a list")
+})
+
+create_query <- function() {
+  bids_query("/tmp", backend = mock_backend)
+}
+
+test_that("subject.bids_query coerces and warns", {
+  q <- create_query()
+  expect_warning(q2 <- subject(q, 1), "character")
+  expect_equal(q2$filters$subjects, "1")
+  expect_warning(q3 <- subject(q, NA_character_), "NA")
+  expect_null(q3$filters$subjects)
+})
+
+test_that("task/session/run/derivatives/space validate inputs", {
+  q <- create_query()
+  expect_warning(q <- task(q, 2), "character")
+  expect_equal(q$filters$tasks, "2")
+
+  q <- create_query()
+  expect_warning(q <- session(q, NA), "NA")
+  expect_null(q$filters$sessions)
+
+  q <- create_query()
+  expect_warning(q <- run(q, 3), "character")
+  expect_equal(q$filters$runs, "3")
+
+  q <- create_query()
+  expect_warning(q <- derivatives(q, 4), "character")
+  expect_equal(q$filters$derivatives, "4")
+
+  q <- create_query()
+  expect_warning(q <- space(q, 5), "character")
+  expect_equal(q$filters$spaces, "5")
+})
+


### PR DESCRIPTION
## Summary
- validate `backend_config` in `bids_backend`
- check and coerce values in `subject.bids_query`, `task.bids_query`, etc.
- add tests for invalid inputs

## Testing
- `Rscript -e "print('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b7135aff8832da3dee756611564ba