### PR TITLE
Add dataset type constant

### DIFF
--- a/R/fmri_dataset_class.R
+++ b/R/fmri_dataset_class.R
@@ -152,7 +152,7 @@ validate_fmri_dataset_structure <- function(x) {
     stop("dataset_type must be specified in metadata")
   }
   
-  if (!x$metadata$dataset_type %in% c("file_vec", "memory_vec", "matrix", "bids_file", "bids_mem")) {
+  if (!x$metadata$dataset_type %in% VALID_DATASET_TYPES) {
     stop("Invalid dataset_type: ", x$metadata$dataset_type)
   }
   

--- a/R/fmri_dataset_validate.R
+++ b/R/fmri_dataset_validate.R
@@ -197,7 +197,7 @@ validate_data_sources <- function(x) {
     stop("metadata$dataset_type is NULL")
   }
   
-  valid_types <- c("file_vec", "memory_vec", "matrix", "bids_file", "bids_mem")
+  valid_types <- VALID_DATASET_TYPES
   if (!dataset_type %in% valid_types) {
     stop("Invalid dataset_type: ", dataset_type, ". Must be one of: ", paste(valid_types, collapse = ", "))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,6 +7,12 @@
 #' @keywords internal
 NULL
 
+#' Valid dataset types recognized by the package
+#'
+#' @keywords internal
+#' @noRd
+VALID_DATASET_TYPES <- c("file_vec", "memory_vec", "matrix", "bids_file", "bids_mem")
+
 #' Determine Dataset Type from Inputs
 #'
 #' Enhanced internal helper that determines the appropriate dataset_type based on 
@@ -135,7 +141,7 @@ determine_dataset_type <- function(images, mask, is_bids = FALSE, preload = FALS
 validate_dataset_type_consistency <- function(dataset_type, images, mask) {
   
   # Validate dataset_type is recognized
-  valid_types <- c("file_vec", "memory_vec", "matrix", "bids_file", "bids_mem")
+  valid_types <- VALID_DATASET_TYPES
   if (!dataset_type %in% valid_types) {
     stop("Invalid dataset_type: ", dataset_type, ". Must be one of: ", 
          paste(valid_types, collapse = ", "))


### PR DESCRIPTION
## Notes
- No R runtime present so tests could not be executed.

## Summary
- define `VALID_DATASET_TYPES` in `utils.R`
- refactor `validate_dataset_type_consistency()` and `validate_fmri_dataset_structure()` to use the constant
- update `validate_data_sources()` to use the new constant


------
https://chatgpt.com/codex/tasks/task_e_683b71876138832dbf5921f419bbb6f1