### PR TITLE
Add transformation pipeline support

### DIFF
--- a/R/fmri_dataset_class.R
+++ b/R/fmri_dataset_class.R
@@ -95,6 +95,9 @@ new_fmri_dataset <- function() {
         extra = list()
       ),
 
+      # --- Transformation Pipeline ---
+      transformation_pipeline = NULL, # transformation_pipeline object
+
       # --- Internal Cache ---
       data_cache = new.env(hash = TRUE, parent = emptyenv()) # For memoized/loaded data
     ),

--- a/R/fmri_dataset_create.R
+++ b/R/fmri_dataset_create.R
@@ -266,6 +266,9 @@ fmri_dataset_create <- function(images,
   
   # === CREATE FMRI_DATASET OBJECT ===
   obj <- new_fmri_dataset()
+
+  # Assign transformation pipeline if provided
+  obj <- set_transformation_pipeline(obj, transformation_pipeline)
   
   # Populate data sources based on dataset_type
   if (dataset_type == "file_vec") {

--- a/tests/testthat/test-constructor.R
+++ b/tests/testthat/test-constructor.R
@@ -183,6 +183,20 @@ test_that("fmri_dataset_create data cache is initialized", {
   expect_equal(ls(dataset$data_cache), character(0))  # Should be empty initially
 })
 
+test_that("fmri_dataset_create stores transformation pipeline", {
+  test_matrix <- matrix(rnorm(20), nrow = 10, ncol = 2)
+  pipe <- transformation_pipeline(transform_detrend())
+
+  dataset <- fmri_dataset_create(
+    images = test_matrix,
+    TR = 1,
+    run_lengths = 10,
+    transformation_pipeline = pipe
+  )
+
+  expect_identical(get_transformation_pipeline(dataset), pipe)
+})
+
 test_that("fmri_dataset_create validates dataset_type determination", {
   # Matrix type
   test_matrix <- matrix(rnorm(1000), nrow = 100, ncol = 10)


### PR DESCRIPTION
## Summary
- add `transformation_pipeline` slot to `fmri_dataset`
- store transformation pipelines when creating datasets
- test that constructor keeps the pipeline

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b7191c4bc832d8016202043ad7f19