### PR TITLE
Add checks for numeric mask and censor vector

### DIFF
--- a/R/fmri_dataset_create.R
+++ b/R/fmri_dataset_create.R
@@ -193,8 +193,11 @@ fmri_dataset_create <- function(images,
         stop("For matrix dataset_type, mask must be logical/numeric vector or NULL")
       }
       
-      # Convert to logical if numeric
+      # Convert to logical if numeric and validate values
       if (is.numeric(mask)) {
+        if (!all(mask %in% c(0, 1))) {
+          stop("Numeric mask values must be 0 or 1")
+        }
         mask <- as.logical(mask)
       }
       
@@ -249,6 +252,10 @@ fmri_dataset_create <- function(images,
   if (!is.null(censor_vector)) {
     if (!is.logical(censor_vector) && !is.numeric(censor_vector)) {
       stop("censor_vector must be logical, numeric, or NULL")
+    }
+
+    if (is.numeric(censor_vector) && !all(censor_vector %in% c(0, 1))) {
+      stop("Numeric censor_vector values must be 0 or 1")
     }
     
     expected_length <- sum(run_lengths)

--- a/man/fmri_dataset_create.Rd
+++ b/man/fmri_dataset_create.Rd
@@ -26,14 +26,15 @@ fmri_dataset_create(
 \arguments{
 \item{images}{Primary image data. Can be a matrix (time x voxels), 
   character vector of file paths, or list of pre-loaded objects.}
-\item{mask}{Spatial mask. Can be a file path, logical vector/matrix, 
-  or pre-loaded mask object. If NULL, all voxels are included.}
+\item{mask}{Spatial mask. Can be a file path, logical vector/matrix,
+  or pre-loaded mask object. Numeric masks must contain only 0/1 values
+  and are converted to logical. If \code{NULL}, all voxels are included.}
 \item{TR}{Numeric repetition time in seconds.}
 \item{run_lengths}{Integer vector specifying the number of timepoints in each run.}
 \item{event_table}{Data frame or path to TSV file containing experimental events. 
   Should include 'onset' and 'duration' columns.}
-\item{censor_vector}{Logical or numeric vector indicating which timepoints to keep 
-  (TRUE/1) or exclude (FALSE/0).}
+\item{censor_vector}{Logical or numeric vector indicating which timepoints to keep
+  (TRUE/1) or exclude (FALSE/0). Numeric vectors must contain only 0/1 values.}
 \item{base_path}{Base directory path for resolving relative file paths.}
 \item{image_mode}{Loading mode for file-based images. One of "normal", "bigvec", "mmap", "filebacked".}
 \item{preload_data}{Logical indicating whether to load data immediately into memory.}

--- a/tests/testthat/test-constructor.R
+++ b/tests/testthat/test-constructor.R
@@ -114,9 +114,24 @@ test_that("fmri_dataset_create handles censoring", {
   expect_equal(get_censor_vector(dataset_numeric), censor_numeric)
 })
 
+test_that("numeric censor_vector values must be 0/1", {
+  test_matrix <- matrix(rnorm(1000), nrow = 100, ncol = 10)
+  bad_censor <- rep(c(0, 1, 2), length.out = 100)
+
+  expect_error(
+    fmri_dataset_create(
+      images = test_matrix,
+      TR = 2.0,
+      run_lengths = c(50, 50),
+      censor_vector = bad_censor
+    ),
+    "Numeric censor_vector values must be 0 or 1"
+  )
+})
+
 test_that("fmri_dataset_create handles masking", {
   test_matrix <- matrix(rnorm(1000), nrow = 100, ncol = 10)
-  
+
   # Logical mask vector
   mask_vector <- c(TRUE, FALSE, TRUE, TRUE, FALSE, TRUE, TRUE, TRUE, FALSE, TRUE)
   
@@ -130,6 +145,30 @@ test_that("fmri_dataset_create handles masking", {
   expect_equal(dataset$mask_vector, mask_vector)
   expect_null(dataset$mask_path)
   expect_null(dataset$mask_object)
+})
+
+test_that("numeric mask values must be 0/1", {
+  test_matrix <- matrix(rnorm(1000), nrow = 100, ncol = 10)
+
+  good_mask <- c(1, 0, 1, 1, 0, 1, 1, 1, 0, 1)
+  dset <- fmri_dataset_create(
+    images = test_matrix,
+    mask = good_mask,
+    TR = 2.0,
+    run_lengths = c(50, 50)
+  )
+  expect_equal(dset$mask_vector, as.logical(good_mask))
+
+  bad_mask <- c(1, 0, 2, 1, 0, 1, 1, 1, 0, 1)
+  expect_error(
+    fmri_dataset_create(
+      images = test_matrix,
+      mask = bad_mask,
+      TR = 2.0,
+      run_lengths = c(50, 50)
+    ),
+    "Numeric mask values must be 0 or 1"
+  )
 })
 
 test_that("fmri_dataset_create handles preprocessing options", {


### PR DESCRIPTION
## Summary
- validate numeric masks contain only 0/1 in `fmri_dataset_create`
- ensure numeric `censor_vector` values are limited to 0/1
- document numeric mask/censor constraints
- add tests for numeric mask and censor vector validation

## Testing
- `R -q -e "testthat::test_local('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b719612bc832daaffc04bc73cc5e3