### PR TITLE
Add memory_vec run-length validation

### DIFF
--- a/R/fmri_dataset_create.R
+++ b/R/fmri_dataset_create.R
@@ -165,7 +165,13 @@ fmri_dataset_create <- function(images,
     if (!is.list(images)) {
       stop("For memory_vec dataset_type, images must be a list of NeuroVec objects")
     }
-    
+
+    # Validate that number of image objects matches run_lengths
+    if (length(images) != length(run_lengths)) {
+      stop("For memory_vec dataset_type, length(images) (", length(images),
+           ") must match length(run_lengths) (", length(run_lengths), ")")
+    }
+
     # TODO: Add NeuroVec class validation when neuroim2 is available
     # This would require conditional checking since neuroim2 is in Suggests
     

--- a/tests/testthat/test-constructor.R
+++ b/tests/testthat/test-constructor.R
@@ -200,4 +200,18 @@ test_that("fmri_dataset_create validates dataset_type determination", {
   dataset_memory$image_objects <- list("obj1", "obj2")
   dataset_memory$metadata <- list(dataset_type = "memory_vec")
   expect_equal(get_dataset_type(dataset_memory), "memory_vec")
-}) 
+})
+
+test_that("fmri_dataset_create validates run_lengths for memory_vec", {
+  img1 <- matrix(rnorm(20), nrow = 2)
+  img2 <- matrix(rnorm(20), nrow = 2)
+  img_list <- list(img1, img2)
+
+  expect_error(
+    fmri_dataset_create(images = img_list, TR = 2.0, run_lengths = 2),
+    "length(images)"
+  )
+
+  dset <- fmri_dataset_create(images = img_list, TR = 2.0, run_lengths = c(2, 2))
+  expect_equal(get_dataset_type(dset), "memory_vec")
+})


### PR DESCRIPTION
## Summary
- validate that `memory_vec` datasets have matching `images` and `run_lengths`
- test the new error branch in constructor

## Testing
- `R` command failed: `bash: R: command not found` (tests could not be run)


------
https://chatgpt.com/codex/tasks/task_e_683b7196a138832db6ea21d963c1fcd3