### PR TITLE
Add family tag to fmri_dataset_create docs

### DIFF
--- a/R/fmri_dataset_create.R
+++ b/R/fmri_dataset_create.R
@@ -70,6 +70,7 @@
 #' )
 #' }
 #'
+#' @family fmri_dataset
 #' @export
 fmri_dataset_create <- function(images, 
                                mask = NULL,


### PR DESCRIPTION
## Summary
- document `fmri_dataset_create` as part of the `fmri_dataset` family
- ensure `R/fmri_dataset_create.R` ends with a newline

## Testing
- `Rscript -e 'sessionInfo()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b71977db0832da3d4765ee2db95ab