### PR TITLE
Set dataset_type for BIDS datasets

### DIFF
--- a/R/fmri_dataset_from_bids.R
+++ b/R/fmri_dataset_from_bids.R
@@ -41,7 +41,11 @@ NULL
 #'   \item Loads event tables from BIDS events.tsv files
 #'   \item Populates comprehensive BIDS metadata
 #' }
-#' 
+#'
+#' The dataset type ("bids_file" or "bids_mem") is determined using
+#' \code{determine_dataset_type(..., is_bids = TRUE, preload = preload_data)} and
+#' stored in \code{dataset$metadata$dataset_type} of the returned object.
+#'
 #' **Image Type Selection (Subtask #9.2):**
 #' - "auto": Prefers preprocessed images if available, falls back to raw
 #' - "raw": Uses raw functional images from main BIDS directory
@@ -135,7 +139,7 @@ as.fmri_dataset.bids_project <- function(x, subject_id,
   final_metadata <- c(metadata, list(bids_info = bids_metadata))
   
   # Call the primary constructor
-  fmri_dataset_create(
+  dataset <- fmri_dataset_create(
     images = func_scans$file_paths,
     mask = mask_info$file_path,
     TR = TR,
@@ -150,6 +154,16 @@ as.fmri_dataset.bids_project <- function(x, subject_id,
     metadata = final_metadata,
     ...
   )
+
+  # Determine dataset type for BIDS source and store
+  dataset$metadata$dataset_type <- determine_dataset_type(
+    func_scans$file_paths,
+    mask_info$file_path,
+    is_bids = TRUE,
+    preload = preload_data
+  )
+
+  dataset
 }
 
 #' Extract Functional Scans from BIDS Project

--- a/tests/testthat/test-bids-dataset-type.R
+++ b/tests/testthat/test-bids-dataset-type.R
@@ -1,0 +1,43 @@
+skip_if_not_installed <- function(pkg) {
+  skip_if_not(requireNamespace(pkg, quietly = TRUE),
+              paste("Package", pkg, "not available"))
+}
+
+
+test_that("BIDS datasets set dataset_type correctly", {
+  skip_if_not_installed("bidser")
+  skip_if_not_installed("neuroim2")
+
+  file_structure_df <- data.frame(
+    subid = c("sub-01"),
+    datatype = c("func"),
+    suffix = c("bold"),
+    fmriprep = c(FALSE),
+    task = c("rest"),
+    stringsAsFactors = FALSE
+  )
+
+  mock_bids <- bidser::create_mock_bids(
+    project_name = "dataset_type_test",
+    participants = c("sub-01"),
+    file_structure = file_structure_df
+  )
+
+  dset_file <- as.fmri_dataset(
+    mock_bids,
+    subject_id = "01",
+    task_id = "rest",
+    preload_data = FALSE
+  )
+
+  expect_equal(get_dataset_type(dset_file), "bids_file")
+
+  dset_mem <- as.fmri_dataset(
+    mock_bids,
+    subject_id = "01",
+    task_id = "rest",
+    preload_data = TRUE
+  )
+
+  expect_equal(get_dataset_type(dset_mem), "bids_mem")
+})


### PR DESCRIPTION
## Summary
- ensure `as.fmri_dataset.bids_project()` assigns the proper `dataset_type`
- document new behaviour for BIDS dataset construction
- add unit tests for BIDS dataset types

## Testing
- `Rscript -e "cat('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b719f8d84832d808c6029e64aa63f