### PR TITLE
Add sampling_frame and internal chunk tests

### DIFF
--- a/tests/testthat/test_internal_chunks.R
+++ b/tests/testthat/test_internal_chunks.R
@@ -1,0 +1,19 @@
+library(fmridataset)
+
+# Tests for exec_strategy and collect_chunks
+
+test_that("exec_strategy and collect_chunks work", {
+  set.seed(1)
+  Y <- matrix(rnorm(50 * 10), 50, 10)
+  dset <- matrix_dataset(Y, TR = 1, run_length = 50)
+
+  strat <- fmridataset:::exec_strategy("chunkwise", nchunks = 3)
+  iter <- strat(dset)
+  chunks <- fmridataset:::collect_chunks(iter)
+
+  expect_equal(length(chunks), 3)
+  expect_true(all(sapply(chunks, inherits, "data_chunk")))
+
+  voxel_inds <- sort(unlist(lapply(chunks, function(ch) ch$voxel_ind)))
+  expect_equal(voxel_inds, 1:10)
+})

--- a/tests/testthat/test_sampling_frame.R
+++ b/tests/testthat/test_sampling_frame.R
@@ -1,0 +1,20 @@
+library(fmridataset)
+
+# Tests for sampling_frame utilities
+
+test_that("sampling_frame utilities work", {
+  sf <- sampling_frame(run_length = c(10, 20, 30), TR = 2)
+
+  expect_true(is.sampling_frame(sf))
+  expect_equal(get_TR(sf), 2)
+  expect_equal(get_run_lengths(sf), c(10, 20, 30))
+  expect_equal(n_runs(sf), 3)
+  expect_equal(n_timepoints(sf), 60)
+  expect_equal(blocklens(sf), c(10, 20, 30))
+  expect_equal(blockids(sf), c(rep(1, 10), rep(2, 20), rep(3, 30)))
+  expect_equal(samples(sf), 1:60)
+  expect_equal(global_onsets(sf), c(1, 11, 31))
+  expect_equal(get_total_duration(sf), 120)
+  expect_equal(get_run_duration(sf), c(20, 40, 60))
+  expect_output(print(sf), "Sampling Frame")
+})


### PR DESCRIPTION
## Summary
- add tests for `sampling_frame` utilities
- test `exec_strategy` and `collect_chunks` internals

## Testing
- `R -q -e 'print("Running tests")'` *(fails: command not found)*
- `Rscript -e 'print("test")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684434664a5c832da5a0ac3157bb9197