### PR TITLE
Increase test coverage with config and error tests

### DIFF
--- a/tests/testthat/test_config.R
+++ b/tests/testthat/test_config.R
@@ -1,0 +1,35 @@
+library(fmridataset)
+
+test_that("default_config returns expected defaults", {
+  cfg <- fmridataset:::default_config()
+  expect_equal(cfg$cmd_flags, "")
+  expect_equal(cfg$jobs, 1)
+})
+
+
+test_that("read_fmri_config parses configuration files", {
+  temp_dir <- tempdir()
+  event_file <- file.path(temp_dir, "events.tsv")
+  write.table(data.frame(onset = c(1,2,3), duration = c(0.5,0.5,0.5)),
+              event_file, row.names = FALSE, sep = "\t")
+
+  cfg_file <- file.path(temp_dir, "config.R")
+  cat(
+    "scans <- c('scan1.nii', 'scan2.nii')\n",
+    "TR <- 2\n",
+    "mask <- 'mask.nii'\n",
+    "run_length <- c(2,2)\n",
+    "event_model <- 'model'\n",
+    "event_table <- 'events.tsv'\n",
+    "block_column <- 'run'\n",
+    "baseline_model <- 'hrf'\n",
+    file = cfg_file
+  )
+
+  cfg <- read_fmri_config(cfg_file, base_path = temp_dir)
+  expect_s3_class(cfg, "fmri_config")
+  expect_equal(cfg$TR, 2)
+  expect_equal(cfg$run_length, c(2,2))
+  expect_equal(nrow(cfg$design), 3)
+  expect_equal(cfg$base_path, temp_dir)
+})

--- a/tests/testthat/test_error_constructors.R
+++ b/tests/testthat/test_error_constructors.R
@@ -1,0 +1,22 @@
+library(fmridataset)
+
+test_that("error constructors create structured errors", {
+  err <- fmridataset:::fmridataset_error_backend_io("oops", file = "f.h5", operation = "read")
+  expect_s3_class(err, "fmridataset_error_backend_io")
+  expect_match(err$message, "oops")
+  expect_equal(err$file, "f.h5")
+  expect_equal(err$operation, "read")
+
+  err2 <- fmridataset:::fmridataset_error_config("bad", parameter = "x", value = 1)
+  expect_s3_class(err2, "fmridataset_error_config")
+  expect_equal(err2$parameter, "x")
+  expect_equal(err2$value, 1)
+})
+
+
+test_that("stop_fmridataset throws the constructed error", {
+  expect_error(
+    fmridataset:::stop_fmridataset(fmridataset:::fmridataset_error_config, "bad", parameter = "y"),
+    class = "fmridataset_error_config"
+  )
+})


### PR DESCRIPTION
## Summary
- add tests for config helper functions
- add tests for custom error constructors

## Testing
- `R CMD check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844cbdca384832d86fb5009faefbac1