### PR TITLE
Add tests for as_delayed_array and run length validation

### DIFF
--- a/tests/testthat/test_as_delayed_array.R
+++ b/tests/testthat/test_as_delayed_array.R
@@ -1,0 +1,40 @@
+library(testthat)
+
+create_matrix_backend <- function() {
+  matrix_backend(matrix(1:20, nrow = 5, ncol = 4))
+}
+
+test_that("as_delayed_array works for matrix_backend", {
+  b <- create_matrix_backend()
+  da <- as_delayed_array(b)
+  expect_s4_class(da, "DelayedArray")
+  expect_equal(dim(da), c(5, 4))
+  expect_equal(as.matrix(da), b$data_matrix)
+  sub <- da[2:4, 2:3]
+  expect_equal(as.matrix(sub), b$data_matrix[2:4, 2:3])
+})
+
+create_nifti_backend <- function() {
+  skip_if_not_installed("neuroim2")
+  dims <- c(2,2,1,5)
+  data_array <- array(seq_len(prod(dims)), dims)
+  mock_vec <- structure(
+    data_array,
+    class = c("DenseNeuroVec", "NeuroVec", "array"),
+    space = structure(list(dim = dims[1:3], origin = c(0,0,0), spacing = c(1,1,1)),
+                     class = "NeuroSpace")
+  )
+  mock_mask <- structure(array(TRUE, dims[1:3]),
+                         class = c("LogicalNeuroVol", "NeuroVol", "array"),
+                         dim = dims[1:3])
+  nifti_backend(source = list(mock_vec), mask_source = mock_mask, preload = TRUE)
+}
+
+test_that("as_delayed_array works for nifti_backend", {
+  b <- create_nifti_backend()
+  da <- as_delayed_array(b)
+  expect_s4_class(da, "DelayedArray")
+  expect_equal(dim(da), c(5, 4))
+  expected <- matrix(seq_len(5*4), nrow = 5, byrow = TRUE)
+  expect_equal(as.matrix(da), expected)
+})

--- a/tests/testthat/test_run_length_validation.R
+++ b/tests/testthat/test_run_length_validation.R
@@ -1,0 +1,18 @@
+library(testthat)
+
+create_study <- function() {
+  b1 <- matrix_backend(matrix(1:10, nrow = 5, ncol = 2), spatial_dims = c(2,1,1))
+  b2 <- matrix_backend(matrix(11:20, nrow = 5, ncol = 2), spatial_dims = c(2,1,1))
+  d1 <- fmri_dataset(b1, TR = 1, run_length = 5)
+  d2 <- fmri_dataset(b2, TR = 1, run_length = 5)
+  fmri_study_dataset(list(d1, d2), subject_ids = c("s1", "s2"))
+}
+
+test_that("run length mismatch triggers error in metadata", {
+  study <- create_study()
+  study$sampling_frame$blocklens[1] <- 6
+  expect_error(
+    fmri_series(study, selector = 1, timepoints = 1:10),
+    "run lengths inconsistent with backend dimensions"
+  )
+})


### PR DESCRIPTION
## Summary
- add new tests for `as_delayed_array()` on matrix and nifti backends
- check that mismatched run lengths trigger errors during `fmri_series`

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479b5ded7c832dbd9e9200f79992a7