### PR TITLE
Fix mask caching validation and add tests

### DIFF
--- a/R/h5_backend.R
+++ b/R/h5_backend.R
@@ -298,8 +298,6 @@ backend_get_mask.h5_backend <- function(backend) {
 
   # Convert to logical vector
   mask_vec <- as.logical(as.vector(mask_vol))
-  backend$mask <- mask_vol
-  backend$mask_vec <- mask_vec
 
   # Validate mask
   if (any(is.na(mask_vec))) {
@@ -317,6 +315,9 @@ backend_get_mask.h5_backend <- function(backend) {
       parameter = "mask"
     )
   }
+
+  backend$mask <- mask_vol
+  backend$mask_vec <- mask_vec
 
   backend$mask_vec
 }

--- a/R/nifti_backend.R
+++ b/R/nifti_backend.R
@@ -227,14 +227,12 @@ backend_get_mask.nifti_backend <- function(backend) {
         )
       }
     )
-    backend$mask <- mask_vol
   } else {
     mask_vol <- backend$mask_source
   }
 
   # Convert to logical vector
   mask_vec <- as.logical(as.vector(mask_vol))
-  backend$mask_vec <- mask_vec
 
   # Validate mask
   if (any(is.na(mask_vec))) {
@@ -252,6 +250,9 @@ backend_get_mask.nifti_backend <- function(backend) {
       parameter = "mask"
     )
   }
+
+  backend$mask <- mask_vol
+  backend$mask_vec <- mask_vec
 
   backend$mask_vec
 }

--- a/tests/testthat/test_mask_caching.R
+++ b/tests/testthat/test_mask_caching.R
@@ -1,0 +1,66 @@
+test_that("nifti_backend caches mask only after validation", {
+  # Minimal mock NeuroVec
+  mock_vec <- structure(
+    array(1:2, c(1, 1, 1, 2)),
+    class = c("DenseNeuroVec", "NeuroVec", "array"),
+    space = structure(list(dim = c(1, 1, 1), origin = c(0, 0, 0), spacing = c(1, 1, 1)),
+                      class = "NeuroSpace")
+  )
+
+  invalid_mask <- structure(
+    array(c(TRUE, NA), c(1, 1, 2)),
+    class = c("LogicalNeuroVol", "NeuroVol", "array"),
+    dim = c(1, 1, 2)
+  )
+
+  backend <- nifti_backend(source = list(mock_vec), mask_source = invalid_mask)
+
+  expect_error(backend_get_mask(backend), "Mask contains NA values")
+  expect_null(backend$mask_vec)
+  expect_null(backend$mask)
+
+  valid_mask <- structure(
+    array(TRUE, c(1, 1, 2)),
+    class = c("LogicalNeuroVol", "NeuroVol", "array"),
+    dim = c(1, 1, 2)
+  )
+  backend$mask_source <- valid_mask
+  mask <- backend_get_mask(backend)
+  expect_true(all(mask))
+  expect_identical(mask, backend$mask_vec)
+})
+
+
+test_that("h5_backend caches mask only after validation", {
+  invalid_mask <- structure(
+    array(c(TRUE, NA), c(1, 1, 1)),
+    class = c("LogicalNeuroVol", "NeuroVol", "array"),
+    dim = c(1, 1, 1)
+  )
+
+  backend <- structure(
+    list(
+      mask_source = invalid_mask,
+      mask = NULL,
+      mask_vec = NULL,
+      source = list(),
+      mask_dataset = "data/elements",
+      data_dataset = "data"
+    ),
+    class = c("h5_backend", "storage_backend")
+  )
+
+  expect_error(backend_get_mask(backend), "H5 mask contains NA values")
+  expect_null(backend$mask_vec)
+  expect_null(backend$mask)
+
+  valid_mask <- structure(
+    array(TRUE, c(1, 1, 1)),
+    class = c("LogicalNeuroVol", "NeuroVol", "array"),
+    dim = c(1, 1, 1)
+  )
+  backend$mask_source <- valid_mask
+  mask <- backend_get_mask(backend)
+  expect_true(all(mask))
+  expect_identical(mask, backend$mask_vec)
+})


### PR DESCRIPTION
## Summary
- ensure mask objects are cached only after passing validation
- always cache nifti backend masks from memory
- add regression tests covering mask validation caching

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f3c1137c832d8e1ce655decdee97